### PR TITLE
Remove the parameter of DocumetnationBuilder

### DIFF
--- a/rfdocsindexer/indexer.py
+++ b/rfdocsindexer/indexer.py
@@ -66,7 +66,7 @@ def _get_libdoc_from_libname_or_path(
     if isinstance(library_name_or_path, Path):
         library_name_or_path = str(library_name_or_path)
     try:
-        return DocumentationBuilder(library_name_or_path).build(library_name_or_path)
+        return DocumentationBuilder().build(library_name_or_path)
     except DataError as err:
         raise RuntimeError(
             f'Error generating documentation for library "{library_name_or_path}": '


### PR DESCRIPTION
Hi, 

I had to adjust indexer.py and remove the parameter of DocumetnationBuilder to make the documentation generation. 
It is consistent with current libdoc documentation. DocumentationBuilder constructor doesn't take any argument. 

Cheers   